### PR TITLE
Fix: wrong mapping ERTYU

### DIFF
--- a/plugin/vim-thai-keys.vim
+++ b/plugin/vim-thai-keys.vim
@@ -68,11 +68,11 @@
 
 :map ๐ Q
 " :map \" W "key already mapped
-:map ำ E
-:map พ R
-:map ะ T
-:map ั Y
-:map ี U
+:map ฎ E
+:map ฑ R
+:map ธ T
+:map ํ Y
+:map ๊ U
 :map ณ I
 :map ฯ O
 :map ญ P

--- a/plugin/vim-thai-keys.vim
+++ b/plugin/vim-thai-keys.vim
@@ -49,6 +49,7 @@
 :map ก d
 :map ด f
 :map เ g
+:map เเ gg
 :map ้ h
 :map ่ j
 :map า k


### PR DESCRIPTION
แก้ไขปุ่มที่แมพไม่ถูกต้อง ERTYU ตัวใหญ่ 
แต่ไปแมพทับกับ ertyu ตัวเล็ก
