### PR TITLE
Unmap _ key and add explanation for "already mapped"

### DIFF
--- a/plugin/vim-thai-keys.vim
+++ b/plugin/vim-thai-keys.vim
@@ -7,7 +7,7 @@
 " :map \- ` " already mapped
 :map ๅ 1
 " :map / 2 " already mapped
-:map _ 3
+" :map _ 3 " already mapped
 :map ภ 4
 :map ถ 5
 :map ุ 6

--- a/plugin/vim-thai-keys.vim
+++ b/plugin/vim-thai-keys.vim
@@ -2,6 +2,9 @@
 " Assumes kedmanee key bindings, for now.
 " Pull requests welcome for more mappings ; - )
 
+" keys that are already mapped are the keys that Vim use by default (because
+" they are available in English keyboard). So we shouldn't remap it to something
+" else without user's acknowledgement
 " ___________________________
 "                KEY MAPPINGS
 " :map \- ` " already mapped


### PR DESCRIPTION
Underscore key is used by Vim. Its behavior by default is similar to `^` but understand count value.
It might not be so useful by default but it's required by some plugin such as https://github.com/terryma/vim-expand-region
This fix will unmap _ to not typing 3 anymore.
@chakrit 